### PR TITLE
Add Xamarin.iOS project files for the Runtime

### DIFF
--- a/src/FsLexYacc.Runtime/FsLexYacc.Runtime.iOS.fsproj
+++ b/src/FsLexYacc.Runtime/FsLexYacc.Runtime.iOS.fsproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectTypeGuids>
+    <ProjectGuid>{0A6D0DB9-D738-4943-A549-40AC359D5B45}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>FsLexYacc.Runtime.iOS</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>FsLexYacc.Runtime.iOS</AssemblyName>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <ConsolePause>false</ConsolePause>
+    <Tailcalls>false</Tailcalls>
+    <PlatformTarget>
+    </PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <PlatformTarget>
+    </PlatformTarget>
+    <ConsolePause>false</ConsolePause>
+    <Tailcalls>true</Tailcalls>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core" />
+    <Reference Include="monotouch" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Lexing.fs" />
+    <Compile Include="Parsing.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Lexing.fsi" />
+    <None Include="Parsing.fsi" />
+  </ItemGroup>
+</Project>

--- a/src/FsLexYacc.Runtime/FsLexYacc.Runtime.iOS.sln
+++ b/src/FsLexYacc.Runtime/FsLexYacc.Runtime.iOS.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "FsLexYacc.Runtime.iOS", "FsLexYacc.Runtime.iOS.fsproj", "{0A6D0DB9-D738-4943-A549-40AC359D5B45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0A6D0DB9-D738-4943-A549-40AC359D5B45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A6D0DB9-D738-4943-A549-40AC359D5B45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A6D0DB9-D738-4943-A549-40AC359D5B45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A6D0DB9-D738-4943-A549-40AC359D5B45}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = FsLexYacc.Runtime.iOS.fsproj
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This adds minimal support for Xamarin.iOS by adding a project and solution file. The end goal is to have a Xamarin.iOS compatible NuGet for Issue #8
