### PR TITLE
Moved the `.targets` file and tools from `bin` to `build'

### DIFF
--- a/nuget/FsLexYacc.nuspec
+++ b/nuget/FsLexYacc.nuspec
@@ -17,10 +17,10 @@
     @dependencies@
   </metadata>
   <files>
-    <file src="..\bin\FSharp.Core.dll" target="bin" />
-    <file src="..\bin\FsLex.exe" target="bin" />
-    <file src="..\bin\FsYacc.exe" target="bin" />
-    <file src="..\bin\FsLexYacc.targets" target="bin" />
-    <file src="..\bin\FsLexYacc.Build.Tasks.dll" target="bin" />
+    <file src="..\bin\FSharp.Core.dll" target="build" />
+    <file src="..\bin\FsLex.exe" target="build" />
+    <file src="..\bin\FsYacc.exe" target="build" />
+    <file src="..\bin\FsLexYacc.targets" target="build" />
+    <file src="..\bin\FsLexYacc.Build.Tasks.dll" target="build" />
   </files>
 </package>


### PR DESCRIPTION
Moved the `.targets` file and build tools from the directory `bin` to `build` in the package so that the targets are imported automatically into a project importing the package.

closed: #26.