### PR TITLE
Issue #5: RCL libraries not available for Linux.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -92,7 +92,8 @@ Target "Build" (fun _ ->
             !! "src/**/*.fsproj"
          else
             !! "src/**/*.fsproj"
-              -- "src/FsLexYacc.Profile259/*.fsproj")
+              -- "src/FsLexYacc.Profile259/*.fsproj"
+              -- "src/FsLexYacc.Profile7/*.fsproj")
           ++ "tests/FsLexYacc.Build.Tasks.Tests/*.fsproj"
 
     projects


### PR DESCRIPTION
Issue #5: RCL libraries not available for Linux. Exclude Profile 7 in addition to Profile 259 when building under Linux.