### PR TITLE
[WIP] Support coreclr using dotnet cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 
+# dotnet cli
+project.lock.json
+
 # =========================
 # Windows detritus
 # =========================

--- a/src/FsLex/NuGet.Config
+++ b/src/FsLex/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/FsLex/fslexast.fs
+++ b/src/FsLex/fslexast.fs
@@ -214,7 +214,11 @@ let LexerStateToNfa (macros: Map<string,_>) (clauses: Clause list) =
             let re = Alt([ yield Inp(Alphabet(EncodeUnicodeCategory uc))
                            // Also include any specific characters in this category
                            for c in GetSingleCharAlphabet() do 
+#if DNXCORE50
+                               if System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c) = unicodeCategories.[uc] then 
+#else
                                if System.Char.GetUnicodeCategory(c) = unicodeCategories.[uc] then 
+#endif
                                     yield Inp(Alphabet(EncodeChar(c))) ])
             CompileRegexp re dest
 
@@ -233,7 +237,11 @@ let LexerStateToNfa (macros: Map<string,_>) (clauses: Clause list) =
                            // That is, negations _only_ exclude precisely the given set of characters. You can't
                            // exclude whole classes of characters as yet
                            if !unicode then 
+#if DNXCORE50
+                               let ucs = chars |> Set.map(DecodeChar >> System.Globalization.CharUnicodeInfo.GetUnicodeCategory)  
+#else
                                let ucs = chars |> Set.map(DecodeChar >> System.Char.GetUnicodeCategory)  
+#endif
                                for KeyValue(nm,uc) in unicodeCategories do
                                    //if ucs.Contains(uc) then 
                                    //    do printfn "warning: the unicode category '\\%s' ('%s') is automatically excluded by this character set negation. Consider adding this to the negation." nm  (uc.ToString())

--- a/src/FsLex/prereq.bat
+++ b/src/FsLex/prereq.bat
@@ -1,0 +1,21 @@
+
+REM
+REM <FsLex Include="fslexlex.fsl">
+REM   <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+REM </FsLex>
+REM
+
+..\..\lkg\bin\fslex.exe -o fslexlex.fs --unicode --lexlib Internal.Utilities.Text.Lexing  fslexlex.fsl
+
+IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
+
+REM
+REM <FsYacc Include="fslexpars.fsy">
+REM   <OtherFlags>--internal --module FsLexYacc.FsLex.Parser --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+REM </FsYacc>
+REM
+
+..\..\lkg\bin\fsyacc.exe -o fslexpars.fs --internal --module FsLexYacc.FsLex.Parser --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing  fslexpars.fsy
+
+IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
+

--- a/src/FsLex/project.json
+++ b/src/FsLex/project.json
@@ -1,0 +1,32 @@
+{
+    "compilerName": "fsc",
+
+    "compilationOptions": {
+        "define": [ "INTERNALIZED_FSLEXYACC_RUNTIME" ],
+        "xmlDoc": true,
+        "emitEntryPoint": true
+    },
+
+    "compileFiles": [
+        "AssemblyInfo.fs",
+        "../FsLexYacc.Runtime/Lexing.fsi",
+        "../FsLexYacc.Runtime/Lexing.fs",
+        "../FsLexYacc.Runtime/Parsing.fsi",
+        "../FsLexYacc.Runtime/Parsing.fs",
+        "../Common/Arg.fsi",
+        "../Common/Arg.fs",
+        "fslexast.fs",
+        "fslexpars.fs",
+        "fslexlex.fs",
+        "fslex.fs"
+    ],
+
+    "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "NETStandard.Library": "1.0.0-rc2-23728"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/src/FsLexYacc.Runtime/Lexing.fs
+++ b/src/FsLexYacc.Runtime/Lexing.fs
@@ -338,10 +338,14 @@ namespace Microsoft.FSharp.Text.Lexing
                         // which covers all Unicode characters not covered in other
                         // ways
                         let baseForUnicodeCategories = numLowUnicodeChars+numSpecificUnicodeChars*2
-#if FX_WINRT || DNXCORE50
+#if FX_WINRT
                         let unicodeCategory = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(inp)
 #else
+    #if DNXCORE50
+                        let unicodeCategory = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(inp)
+    #else
                         let unicodeCategory = System.Char.GetUnicodeCategory(inp)
+    #endif
 #endif
                         //System.Console.WriteLine("inp = {0}, unicodeCategory = {1}", [| box inp; box unicodeCategory |]);
                         int trans.[state].[baseForUnicodeCategories + int32 unicodeCategory]

--- a/src/FsLexYacc.Runtime/Lexing.fs
+++ b/src/FsLexYacc.Runtime/Lexing.fs
@@ -338,7 +338,7 @@ namespace Microsoft.FSharp.Text.Lexing
                         // which covers all Unicode characters not covered in other
                         // ways
                         let baseForUnicodeCategories = numLowUnicodeChars+numSpecificUnicodeChars*2
-#if FX_WINRT
+#if FX_WINRT || DNXCORE50
                         let unicodeCategory = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(inp)
 #else
                         let unicodeCategory = System.Char.GetUnicodeCategory(inp)

--- a/src/FsYacc/NuGet.Config
+++ b/src/FsYacc/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/FsYacc/fsyacc.fs
+++ b/src/FsYacc/fsyacc.fs
@@ -521,7 +521,7 @@ let main() =
       let ty = types.[id] in 
       cprintfn cosi "val %s : (%s.LexBuffer<%s> -> token) -> %s.LexBuffer<%s> -> (%s) " id lexlib tychar lexlib tychar ty;
 
-  logf (fun oso -> oso.Close())
+  logf (fun oso -> oso.Dispose())
 
 let _ = 
     try main()

--- a/src/FsYacc/prereq.bat
+++ b/src/FsYacc/prereq.bat
@@ -1,0 +1,25 @@
+
+REM
+REM <FsLex Include="fsyacclex.fsl">
+REM   <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+REM </FsLex>
+REM
+
+..\..\lkg\bin\fslex.exe -o fsyacclex.fs --unicode --lexlib Internal.Utilities.Text.Lexing  fsyacclex.fsl
+
+IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
+
+REM 
+REM <FsYacc Include="fsyaccpars.fsy">
+REM   <OtherFlags>--internal --module FsLexYacc.FsYacc.Parser --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+REM </FsYacc>
+REM
+
+..\..\lkg\bin\fsyacc.exe -o fsyaccpars.fs --internal --module FsLexYacc.FsYacc.Parser --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing  fsyaccpars.fsy
+
+IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
+
+REM compiler command line
+REM
+REM fsc.exe -o:obj\Release\fsyacc.exe -g --debug:pdbonly --noframework --define:INTERNALIZED_FSLEXYACC_RUNTIME --doc:..\..\bin\fsyacc.xml --optimize+ -r:"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll" -r:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\mscorlib.dll" -r:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll" -r:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll" --target:exe --warnaserror:76 --fullpaths --flaterrors --highentropyva- "C:\Users\E.SADA\AppData\Local\Temp\.NETFramework,Version=v4.0.AssemblyAttributes.fs" AssemblyInfo.fs ..\FsLexYacc.Runtime\Lexing.fsi ..\FsLexYacc.Runtime\Lexing.fs ..\FsLexYacc.Runtime\Parsing.fsi ..\FsLexYacc.Runtime\Parsing.fs ..\Common\Arg.fsi ..\Common\Arg.fs fsyaccast.fs fsyaccpars.fs fsyacclex.fs fsyacc.fs 
+

--- a/src/FsYacc/project.json
+++ b/src/FsYacc/project.json
@@ -1,0 +1,32 @@
+{
+    "compilerName": "fsc",
+
+    "compilationOptions": {
+        "define": [ "INTERNALIZED_FSLEXYACC_RUNTIME" ],
+        "xmlDoc": true,
+        "emitEntryPoint": true
+    },
+
+    "compileFiles": [
+        "AssemblyInfo.fs",
+        "../FsLexYacc.Runtime/Lexing.fsi",
+        "../FsLexYacc.Runtime/Lexing.fs",
+        "../FsLexYacc.Runtime/Parsing.fsi",
+        "../FsLexYacc.Runtime/Parsing.fs",
+        "../Common/Arg.fsi",
+        "../Common/Arg.fs",
+        "fsyaccast.fs",
+        "fsyaccpars.fs",
+        "fsyacclex.fs",
+        "fsyacc.fs"
+    ],
+
+    "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "NETStandard.Library": "1.0.0-rc2-23728"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
for `src/FsYacc`, `src/FsLex`
- `prereq.bat`
- `dotnet restore`
- `dotnet build`

NOTE require a custom built version of dotnet cli, i'll add info about it

It's a wip, but i'd like to use coreclr version of fslex/fsyac in visualfsharp repo

TODO:
- [ ] remove `prereq.bat` 
- [ ] create dotnetcli tool
  - [ ] `fsyacc` => `dotnet-fsyacc`
  - [ ] `fslex` => `dotnet-fslex`
  - [ ] add `{Lexing,Parsing}.{fs,fsi}` source as package to make it possibile to not depends on `FsLexYacc.Runtime.dll`
- [ ] integrate in fake build script
- [ ] integrate in tests
