### PR TITLE
Fix an error preventing the use of verbose mode

### DIFF
--- a/src/FsYacc/fsyaccast.fs
+++ b/src/FsYacc/fsyaccast.fs
@@ -444,7 +444,7 @@ let CompilerLalrParserSpec logf (spec : ProcessedParserSpec) =
         let prodIdx = prodIdx_of_item0 item0
         let dotIdx = dotIdx_of_item0 item0
         let syms = prodTab.Symbols prodIdx
-        syms.[..dotIdx-1]
+        if dotIdx <= 0 then [||] else syms.[..dotIdx-1]
 
     let rsyms_of_item0 item0 = 
         let prodIdx = prodIdx_of_item0 item0


### PR DESCRIPTION
Close #66.

I'm moving an in-house tool from the old fslex/fsyacc in F# Power Pack to fslexyacc NuGet package. Surprisingly the verbose mode (`-v`  option) doesn't work on the latest NuGet packages.

After debugging, it turns out that the code based on an old behaviour of FSharp.Core that has been changed in F# 3.1.2. 

Before F# 3.1.2:
`arr.[.. -1]` would return `[||]`

With F# >= 3.1.2:

`arr.[.. -1]` throws an out of range exception.

The changes seem to be in this commit https://github.com/Microsoft/visualfsharp/commit/d8ee80fe45c348cb98fd13d8649993e09131cfa0.

So the fslexyacc will subtly change its behaviour depending on which FSharp.Core version it's linked to. This PR makes a simple change to explicitly return `[||]` instead of throwing exceptions on negative ranges.

/cc @dsyme @sergey-tihon for quick reviews.