### PR TITLE
Add snapshot source to nuget

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,3 +38,6 @@
 #### 7.0.5 - February 1, 2017
 * Fix an error preventing the use of verbose mode
 
+#### 7.0.6 - 23 June, 2017
+* Add source to build
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2017
 init:
   - git config --global core.autocrlf input
 build_script:

--- a/build.fsx
+++ b/build.fsx
@@ -160,8 +160,14 @@ Target "All" DoNothing
   ==> "GenerateDocs"
   ==> "ReleaseDocs"
 
-"All"
+"Build"
   ==> "NuGet"
+
+"All" 
   ==> "Release"
+
+"NuGet" 
+  ==> "Release"
+
 
 RunTargetOrDefault "All"

--- a/nuget/FsLexYacc.template
+++ b/nuget/FsLexYacc.template
@@ -16,5 +16,30 @@ files
   ../bin/fslex.exe ==> build
   ../bin/fsyacc.exe ==> build
   ../bin/FsLexYacc.targets ==> build
+  ../src/FsLexYacc.Runtime/Lexing.fsi ==> src/fslex
+  ../src/FsLexYacc.Runtime/Lexing.fs ==> src/fslex
+  ../src/FsLexYacc.Runtime/Parsing.fsi ==> src/fslex
+  ../src/FsLexYacc.Runtime/Parsing.fs ==> src/fslex
+  ../src/Common/Arg.fsi ==> src/fslex
+  ../src/Common/Arg.fs ==> src/fslex
+  ../src/FsLex/fslexast.fs ==> src/fslex
+  ../src/FsLex/fslexpars.fs ==> src/fslex
+  ../src/FsLex/fslexlex.fs ==> src/fslex
+  ../src/FsLex/fslex.fs ==> src/fslex
+  ../src/FsLex/App.config ==> src/fslex
+  ../src/FsLex/fslex.fsx ==> src/fslex
+  ../src/FsLexYacc.Runtime/Lexing.fsi ==> src/fsyacc
+  ../src/FsLexYacc.Runtime/Lexing.fs ==> src/fsyacc
+  ../src/FsLexYacc.Runtime/Parsing.fsi ==> src/fsyacc
+  ../src/FsLexYacc.Runtime/Parsing.fs ==> src/fsyacc
+  ../src/Common/Arg.fsi ==> src/fsyacc
+  ../src/Common/Arg.fs ==> src/fsyacc
+  ../src/FsYacc/fsyaccast.fs ==> src/fsyacc
+  ../src/FsYacc/fsyaccpars.fs ==> src/fsyacc
+  ../src/FsYacc/fsyacclex.fs ==> src/fsyacc
+  ../src/FsYacc/fsyacc.fs ==> src/fsyacc
+  ../src/FsYacc/App.config ==> src/fsyacc
+  ../src/FsYacc/fsyacc.fsx ==> src/fsyacc
+  ../src/FsLexYacc.Build.Tasks/FsLexYacc.targets ==> src
 dependencies
   FsLexYacc.Runtime ~> CURRENTVERSION

--- a/src/FsLex/AssemblyInfo.fs
+++ b/src/FsLex/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLex")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("7.0.5")>]
-[<assembly: AssemblyFileVersionAttribute("7.0.5")>]
+[<assembly: AssemblyVersionAttribute("7.0.6")>]
+[<assembly: AssemblyFileVersionAttribute("7.0.6")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLex"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "7.0.5"
-    let [<Literal>] AssemblyFileVersion = "7.0.5"
+    let [<Literal>] AssemblyVersion = "7.0.6"
+    let [<Literal>] AssemblyFileVersion = "7.0.6"

--- a/src/FsLex/fslex.fs
+++ b/src/FsLex/fslex.fs
@@ -222,4 +222,4 @@ let main() =
     exit 1
 
 
-let _ = main()
+let result = main()

--- a/src/FsLex/fslex.fsx
+++ b/src/FsLex/fslex.fsx
@@ -1,0 +1,3 @@
+#load "Lexing.fsi" "Lexing.fs" "Parsing.fsi" "Parsing.fs" "Arg.fsi" "Arg.fs" "fslexast.fs" "fslexpars.fs" "fslexlex.fs" "fslex.fs"
+
+let v = FsLexYacc.FsLex.Driver.result 

--- a/src/FsLexYacc.Runtime/AssemblyInfo.fs
+++ b/src/FsLexYacc.Runtime/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLexYacc.Runtime")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc.Runtime")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("7.0.5")>]
-[<assembly: AssemblyFileVersionAttribute("7.0.5")>]
+[<assembly: AssemblyVersionAttribute("7.0.6")>]
+[<assembly: AssemblyFileVersionAttribute("7.0.6")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLexYacc.Runtime"
     let [<Literal>] AssemblyProduct = "FsLexYacc.Runtime"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "7.0.5"
-    let [<Literal>] AssemblyFileVersion = "7.0.5"
+    let [<Literal>] AssemblyVersion = "7.0.6"
+    let [<Literal>] AssemblyFileVersion = "7.0.6"

--- a/src/FsYacc/AssemblyInfo.fs
+++ b/src/FsYacc/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsYacc")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("7.0.5")>]
-[<assembly: AssemblyFileVersionAttribute("7.0.5")>]
+[<assembly: AssemblyVersionAttribute("7.0.6")>]
+[<assembly: AssemblyFileVersionAttribute("7.0.6")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsYacc"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "7.0.5"
-    let [<Literal>] AssemblyFileVersion = "7.0.5"
+    let [<Literal>] AssemblyVersion = "7.0.6"
+    let [<Literal>] AssemblyFileVersion = "7.0.6"

--- a/src/FsYacc/fsyacc.fs
+++ b/src/FsYacc/fsyacc.fs
@@ -523,7 +523,7 @@ let main() =
 
   logf (fun oso -> oso.Close())
 
-let _ = 
+let result = 
     try main()
     with e -> 
       eprintf "FSYACC: error FSY000: %s" (match e with Failure s -> s | e -> e.Message);

--- a/src/FsYacc/fsyacc.fsx
+++ b/src/FsYacc/fsyacc.fsx
@@ -1,0 +1,3 @@
+#load "Lexing.fsi" "Lexing.fs" "Parsing.fsi" "Parsing.fs" "Arg.fsi" "Arg.fs" "fsyaccast.fs" "fsyaccpars.fs" "fsyacclex.fs" "fsyacc.fs"
+
+let v = FsLexYacc.FsYacc.Driver.result 


### PR DESCRIPTION
For some purposes it is useful for environments using FsLex and FsYacc to have a source copy of these tools rather than binary copies - this is for "source only" builds starting with nothing but a simple SDK.

So we snapshot the source for a particular version and put it in the Nuget in an easily buildable form

To build the source  use

    fsc --define:INTERNALIZED_FSLEXYACC_RUNTIME packages\FsLexYacc\src\fslex\fslex.fsx
    fsc --define:INTERNALIZED_FSLEXYACC_RUNTIME packages\FsLexYacc\src\fsyacc\fsyacc.fsx

Then run fslex.exe and fsyacc.exe as normal.  If for some reason your F# build environment doesn't compile F# scripts properly, then compile the source lists found in fslex.fsx and fsyacc.fsc

