### PR TITLE
Fix the lineno and column of error messages of JsonLexAndYaccExample

### DIFF
--- a/tests/JsonLexAndYaccExample/Lexer.fsl
+++ b/tests/JsonLexAndYaccExample/Lexer.fsl
@@ -12,7 +12,7 @@ exception SyntaxError of string
 let lexeme = LexBuffer<_>.LexemeString
 
 let newline (lexbuf: LexBuffer<_>) = 
-  lexbuf.StartPos <- lexbuf.StartPos.NextLine
+  lexbuf.EndPos <- lexbuf.EndPos.NextLine
 }
 
 let int = ['-' '+']? ['0'-'9']+
@@ -41,7 +41,7 @@ rule read =
   | ':'      { COLON }
   | ','      { COMMA }
   | eof      { EOF }
-  | _ { raise (Exception (sprintf "SyntaxError: Unexpected char: '%s' Line: %d Column: %d" (lexeme lexbuf) (lexbuf.StartPos.Line+1) lexbuf.StartPos.Column)) }
+  | _ { raise (Exception (sprintf "SyntaxError: Unexpected char: '%s' Line: %d Column: %d" (lexeme lexbuf) (lexbuf.StartPos.Line+1) (lexbuf.StartPos.Column+1))) }
 
 
 and read_string str ignorequote =

--- a/tests/JsonLexAndYaccExample/Program.fs
+++ b/tests/JsonLexAndYaccExample/Program.fs
@@ -32,7 +32,7 @@ let main argv =
 
     //test lexing error 
     try
-        let simpleJson = "{\"f\" ;"
+        let simpleJson = "{\"f\"\n" + "\n" + ";"
         let parseResult = simpleJson |> parse 
         printfn "%s" (JsonValue.print parseResult.Value)
     with 


### PR DESCRIPTION
This pull request fixes the problem about lineno and column of error messages of `tests/JsonLexAndYaccExample/Lexer.fsl`.

`lexbuf.StartPos <- lexbuf.StartPos.NextLine` seems to have no effect and the same problem to https://stackoverflow.com/questions/7928438/meaningful-errors-during-parsing-with-fsyacc happens. `lexbuf.EndPos <- lexbuf.EndPos.NextLine` fixes this. We use such tests also as examples of usage, so this should be fixed.