### PR TITLE
Fix a bug in the lexer's NFANodeIdSet.Equals.

### DIFF
--- a/src/FsLex/fslexast.fs
+++ b/src/FsLex/fslexast.fs
@@ -272,29 +272,12 @@ type internal NfaNodeIdSet(nodes: NfaNodeIdSetBuilder) =
     member x.Elements = s 
     member x.Fold f z = Array.fold f z s
     interface System.IComparable with 
-        member x.CompareTo(y:obj) = 
-            let y = (y :?> NfaNodeIdSet)
-            let xr = x.Representation
-            let yr = y.Representation
-            let c = compare xr.Length yr.Length
-            if c <> 0 then c else 
-            let n = yr.Length
-            let rec go i = 
-                if i >= n then 0 else
-                let c = compare xr.[i] yr.[i]
-                if c <> 0 then c else
-                go (i+1) 
-            go 0
+        member x.CompareTo(y:obj) =
+            Array.compareWith compare x.Representation (y :?> NfaNodeIdSet).Representation
 
     override x.Equals(y:obj) = 
         match y with 
-        | :? NfaNodeIdSet as y -> 
-            let xr = x.Representation
-            let yr = y.Representation
-            let n = yr.Length
-            xr.Length = n && 
-            (let rec go i = (i < n) && xr.[i] = yr.[i] && go (i+1) 
-             go 0)
+        | :? NfaNodeIdSet as y -> x.Representation = y.Representation
         | _ -> false
 
     override x.GetHashCode() = hash s


### PR DESCRIPTION
The implementation of NFANodeIdSet.Equals has a bug. But first, let's take a look at the code itself:

``` fsharp
let xr = x.Representation	
let yr = y.Representation	
let n = yr.Length	
xr.Length = n && 	
(let rec go i = (i < n) && xr.[i] = yr.[i] && go (i+1) 	
 go 0)
```

The function `go` was supposed to check each element of the two arrays to see whether they are equal. If they aren't it returns `false`.

The question is when does it return `true`? The answer is never. There is no base case in this recursion that would make it to _ever_ return `true`. So, in case the arrays are equal, the compiler moves the loop index forward, past the end of the array and mistakenly says that the arrays are not equal.

Even by looking at the generated C# code, it is clearly shown that the function is destined to always return `false`:

![The C# code of NFANodeIdSet.Equals' buggy function](https://user-images.githubusercontent.com/12659251/64366102-33502f00-d01e-11e9-9b0b-9674a2bc029f.png)

I thought first to change the expression into something like `i >= n || (xr.[i] = yr.[i] && go (i+1))`. But simply using the equality operator on the arrays themselves is much simpler. I also simplified the `CompareTo` method like this. The generic comparison will not be that heavy, because the arrays actually contain simple integer types.

---

As a sidenote, the "infinite loop" in the commit message turned to be misleading. I found this bug while trying to find why the CI build for #98 had timed out. I thought it was an infinite loop, but the cause of the bug was different. Because I replaced a `Set<NFANodeId>`, that uses a tree, with a `HashSet<NFANodeId>`, that uses a hashmap, the new set type uses the buggy `Equals` method and apparently enters an infinite loop when encountering an element that cannot be equal with anything else (not even itself).