### PR TITLE
Fix errors/typos in jsonParserExample.md

### DIFF
--- a/docs/content/jsonParserExample.md
+++ b/docs/content/jsonParserExample.md
@@ -180,7 +180,7 @@ Reload/Open project and add below code to ``Lexer.fsl:``
     
     exception SyntaxError of string
     
-    let lexeme = LexBuffer.LexemeString
+    let lexeme = LexBuffer<_>.LexemeString
     
     let newline (lexbuf: LexBuffer<_>) = 
       lexbuf.StartPos <- lexbuf.StartPos.NextLine
@@ -251,7 +251,7 @@ The last piece of the puzzle is to write program which will user parser. Look at
     [<EntryPoint>]
     let main argv =
         let parse json = 
-            let lexbuf = LexBuffer<char<.FromString json
+            let lexbuf = LexBuffer<char>.FromString json
             let res = Parser.start Lexer.read lexbuf
             res
         let simpleJson = @"{


### PR DESCRIPTION
Added type instantiation to remove compiler warning
`  Lexer.fsl(9, 14): [FS1125] The instantiation of the generic type 'LexBuffer' is missing and can't be inferred from the arguments or return type of this member. Consider providing a type instantiation when accessing this type, e.g. 'LexBuffer<_>'.`

Fixed brackets to match