### PR TITLE
update docs: 'lexbuf' to 'LexBuffer'

### DIFF
--- a/docs/content/fsyacc.md
+++ b/docs/content/fsyacc.md
@@ -153,7 +153,7 @@ Each action in an fsyacc parser has access to a parseState value through which y
 
 You must set the initial position when you create the lexbuf:
 
-    let setInitialPos (lexbuf:lexbuf) filename =
+    let setInitialPos (lexbuf:LexBuffer<_>) filename =
          lexbuf.EndPos <- { pos_bol = 0;
                             pos_fname=filename;
                             pos_cnum=0;


### PR DESCRIPTION
At https://fsprojects.github.io/FsLexYacc/fsyacc.html

> You must set the initial position when you create the lexbuf:
> ```F#
> let setInitialPos (lexbuf:lexbuf) filename =
>     lexbuf.EndPos <- { pos_bol = 0;
>                        pos_fname=filename;
>                        pos_cnum=0;
>                        pos_lnum=1 }
> ```

This is out-of-date and misleading to users, and shall update to

> ```F#
> let setInitialPos (lexbuf: LexBuffer<_>) filename =
>     lexbuf.EndPos <- { pos_bol = 0;
>                        pos_fname=filename;
>                        pos_cnum=0;
>                        pos_lnum=1 }
> ```