### PR TITLE
Keyword disasm

### DIFF
--- a/src/FsYacc/fsyacc.fs
+++ b/src/FsYacc/fsyacc.fs
@@ -66,6 +66,9 @@ let usage =
 
 let _ = ArgParser.Parse(usage,(fun x -> match !input with Some _ -> failwith "more than one input given" | None -> input := Some x),"fsyacc <filename>")
 
+// This is to avoid name conflicts against keywords.
+let generic_nt_name nt = "'gentype_" + nt
+
 let output_int os n = fprintf os "%d" n
 
 let outputCodedUInt16 os n = fprintf os "%dus; " n
@@ -433,7 +436,7 @@ let main() =
       cprintfn cos "|]" ;
   end;
   
-  let getType nt = if types.ContainsKey nt then  types.[nt] else "'"+nt 
+  let getType nt = if types.ContainsKey nt then  types.[nt] else generic_nt_name nt
   begin 
       cprintf cos "let _fsyacc_reductions ()  =" ;
       cprintfn cos "    [| " ;
@@ -478,7 +481,7 @@ let main() =
           match code with 
           | Some (_,pos) -> cprintfn cos "# %d \"%s\"" pos.pos_lnum pos.pos_fname
           | None -> ()
-          cprintfn cos "                 : %s));" (if types.ContainsKey nt then  types.[nt] else "'"+nt);
+          cprintfn cos "                 : %s));" (if types.ContainsKey nt then  types.[nt] else generic_nt_name nt);
       done;
       cprintfn cos "|]" ;
   end;

--- a/tests/LexAndYaccMiniProject/Parser.fsy
+++ b/tests/LexAndYaccMiniProject/Parser.fsy
@@ -20,8 +20,13 @@
 
 // These are the rules of the grammar along with the F# code of the 
 // actions executed as rules are reduced.  
-start: File EOF { $1 }
+start: File end { $1 }
+     | end      { $1 }
 
 File:
 	| HELLO						{ 1 }
-	| HELLO HELLO				    { 2 }
+	| HELLO HELLO				{ 2 }
+
+
+// Using F# keywords for nonterminal names is okay.
+end: EOF { 3 }


### PR DESCRIPTION
A `'nonterminal` is renamed to `'gentype_nonterminal` if applicable.