### PR TITLE
Update FsLexYacc.targets

### DIFF
--- a/src/FsLexYacc.Build.Tasks/FsLexYacc.targets
+++ b/src/FsLexYacc.Build.Tasks/FsLexYacc.targets
@@ -15,11 +15,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<CompileDependsOn>CallFsLex;CallFsYacc;$(CompileDependsOn)</CompileDependsOn>
-		<FsLexToolPath Condition="'$(FsLexToolPath)' == '' AND '$(MSBuildRuntimeType)'=='Core'">$(MSBuildThisFileDirectory)/fslex/netcoreapp3.1</FsLexToolPath>
-		<FsLexToolExe Condition="'$(FsLexToolExe)' == '' AND '$(MSBuildRuntimeType)'=='Core'">fslex.dll</FsLexToolExe>
-		<FsYaccToolPath Condition="'$(FsYaccToolPath)' == '' AND '$(MSBuildRuntimeType)'=='Core'">$(MSBuildThisFileDirectory)/fsyacc/netcoreapp3.1</FsYaccToolPath>
-		<FsYaccToolExe Condition="'$(FsYaccToolExe)' == '' AND '$(MSBuildRuntimeType)'=='Core'">fsyacc.dll</FsYaccToolExe>
-		<FsLexYaccToolRunner Condition="'$(UseFsLexYaccToolRunner)' != 'false' AND '$(FsLexYaccToolRunner)' == '' AND '$(MSBuildRuntimeType)'=='Core'">dotnet </FsLexYaccToolRunner>
+		<FsLexToolPath Condition="'$(FsLexToolPath)' == ''">$(MSBuildThisFileDirectory)/fslex/netcoreapp3.1</FsLexToolPath>
+		<FsLexToolExe Condition="'$(FsLexToolExe)' == ''">fslex.dll</FsLexToolExe>
+		<FsYaccToolPath Condition="'$(FsYaccToolPath)' == ''">$(MSBuildThisFileDirectory)/fsyacc/netcoreapp3.1</FsYaccToolPath>
+		<FsYaccToolExe Condition="'$(FsYaccToolExe)' == ''">fsyacc.dll</FsYaccToolExe>
+		<FsLexYaccToolRunner Condition="'$(UseFsLexYaccToolRunner)' != 'false' AND '$(FsLexYaccToolRunner)' == ''">dotnet </FsLexYaccToolRunner>
 	</PropertyGroup>
 
 	<!-- Build FsLex files. -->


### PR DESCRIPTION
Removed conditions that require the MSBuildRuntimeType to be 'Core'.

This prevents build run issues in Visual Studio 2019 as discussed in #142.

The conditions were useful in previous versions to distinguish a build on a .Net Core system from a build on a Windows net46 system. Now that there are no alternatives since 10.2.0 you need dotnet any way and this extra conditions only causes the mentioned erratic behaviour in Visual Studio 2019.

This resolved #142