### PR TITLE
Avoid copying a string twice in `LexBuffer.FromString`.

### DIFF
--- a/docs/content/fslex.md
+++ b/docs/content/fslex.md
@@ -258,7 +258,7 @@ Some ways of creating lex buffers are by using:
     LexBuffer<_>.FromFunction
     LexBuffer<_>.FromStream
     LexBuffer<_>.FromTextReader
-    LexBuffer<_>.FromArray
+    LexBuffer<_>.FromBytes
 
 Within lexing actions the variable `lexbuf` is in scope and you may use properties on the `LexBuffer` type such as:
 

--- a/src/FsLexYacc.Runtime/Lexing.fs
+++ b/src/FsLexYacc.Runtime/Lexing.fs
@@ -220,19 +220,18 @@ and [<Sealed>]
             new LexBuffer<_> 
                 { fillSync = Some (fun _ -> ()) 
                   fillAsync = Some (fun _ -> async { return () }) }
-        let buffer = Array.copy s 
-        lexBuffer.Buffer <- buffer
-        lexBuffer.BufferMaxScanLength <- buffer.Length
+        lexBuffer.Buffer <- s
+        lexBuffer.BufferMaxScanLength <- s.Length
         lexBuffer
 
     static member FromBytes (arr) =
-        LexBuffer<byte>.FromArray(arr)
+        LexBuffer<byte>.FromArray(Array.copy arr)
 
     static member FromChars (arr) =
-        LexBuffer<char>.FromArray(arr) 
+        LexBuffer<char>.FromArray(Array.copy arr)
 
     static member FromString (s:string) =
-        LexBuffer<char>.FromChars (s.ToCharArray())
+        LexBuffer<char>.FromArray (s.ToCharArray())
 
     static member FromTextReader (tr:System.IO.TextReader) : LexBuffer<char> = 
        LexBuffer<char>.FromReadFunctions(Some tr.Read, Some (tr.ReadAsync >> Async.AwaitTask))


### PR DESCRIPTION
`LexBuffer.FromString` used to copy a string to an array and then pass it to `FromArray` via `FromChars` which copies it again, resulting in wasteful allocations.

While entirely eliminating the copies would require non-trivial rearchitecturing, this PR eliminates one of the two by moving the `Array.Copy` call from `FromArray` to `FromBytes` and `FromChars`, and by modifying `FromString` to directly call `FromArray`.

Also a piece of documentation was updated to remove mentions to the non-public `FromArray`.