### PR TITLE
Add test and fix #141

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ tests/fsyacc/unicode/test1-unicode.input3.tokens.bsl.err
 tests/fsyacc/Test2/test2lex.fs
 tests/fsyacc/Test2/test2.fs
 tests/fsyacc/Test2/test2.fsi
+tests/fsyacc/repro_#141/Lexer_fail_option_i.fs

--- a/tests/fsyacc/OldFsYaccTests.fsx
+++ b/tests/fsyacc/OldFsYaccTests.fsx
@@ -200,3 +200,9 @@ runTests test2Proj [
     sprintf "--tokens %s" test2Input1, test2Input1TokensBsl
     sprintf "--tokens %s" test2BadInput, test2BadInputTokensBsl
     ]
+
+// #141 TODO
+let repro141Fsl = Path.Combine(__SOURCE_DIRECTORY__, "repro_#141", "Lexer_fail_option_i.fsl")
+let repro141Fs = Path.Combine(__SOURCE_DIRECTORY__, "repro_#141", "Lexer_fail_option_i.fs")
+fsLex ("-i -o " + repro141Fs + " " + repro141Fsl)
+fsLex ("--unicode -i -o " + repro141Fs + " " + repro141Fsl)

--- a/tests/fsyacc/repro_#141/Lexer_fail_option_i.fsl
+++ b/tests/fsyacc/repro_#141/Lexer_fail_option_i.fsl
@@ -1,0 +1,21 @@
+{
+
+module Lexer
+
+// Opens methods related to fslex.exe
+open FSharp.Text.Lexing
+}
+
+// Regular expressions
+let whitespace = [' ' '\t' ]
+let newline = ('\n' | '\r' '\n')
+
+rule tokenstream = parse
+// --------------------------
+| whitespace             { tokenstream lexbuf }
+
+// --------------------------
+| newline        { newline lexbuf; tokenstream lexbuf }
+// --------------------------
+| _              { raise (new EqInterpretationReglesException (sprintf "[Lexer] Erreur %s %d %d" (LexBuffer<_>.LexemeString lexbuf) (lexbuf.StartPos.Line + 1) lexbuf.StartPos.Column)) }
+| eof            { Parser.EOF }


### PR DESCRIPTION
### Problem
Given the way `fslex` works at the moment (using UTF-8's 0-255 range as "code page" when generating non-Unicode lexer) it is not true that the lower/upper counterpart of the letter we are processing is also in the 0-255 range.

### Solution
Add check and only include the upper/lower version of the letter if is it is in the accepted range.

### Note
One could argue that the real problem is that `--codepage` parameter of `fslex` is only used as codepage for interpretation of input `*.fsl` file and not as the base for generated lexer in non-Unicode mode (generated lexer is always based on UTF-8 and interprets bytes from `LexBuffer<byte>` as UTF-8 input). The problem is that changing that would be a breaking change for current `--codepage` and no `--unicode` options users.