### PR TITLE
Publish new versions on master

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,26 @@
+name: Build and test
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET for main project build
+      uses: actions/setup-dotnet@v3
+    - name: Install local tools
+      run: dotnet tool restore
+    - name: Paket restore
+      run: dotnet paket restore
+    - name: Build
+      run: dotnet fake run build.fsx

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,10 +1,7 @@
-name: Build and test
+name: Build and Test and Publish (master)
 
 on:
   push:
-    branches:
-    - master
-  pull_request:
     branches:
     - master
 
@@ -14,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,4 +23,6 @@ jobs:
     - name: Paket restore
       run: dotnet paket restore
     - name: Build
-      run: dotnet fake run build.fsx
+      run: dotnet fake run build.fsx -t Release
+    - name: Publish NuGets (if main version changed)
+      run: dotnet nuget push "bin/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_KEY }} --skip-duplicate

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 11.0.0 - 10 January, 2022
+* Migration to net6.0 #166
+* Fix Activating case insensitive option crash the lexer generator #141
+* Reuse produced reductions table #141
+
 #### 11.0.0-beta1 - 11 July, 2021
 * Break out core domain logic and generation into core libraries #144
 * Update FsLexYacc.targets #149

--- a/build.fsx
+++ b/build.fsx
@@ -165,19 +165,8 @@ Target.create "RunOldFsYaccTests" (fun _ ->
 
 Target.create "NuGet" (fun _ ->
     // project-specific packages
-    DotNet.pack (fun p -> 
-        { p with 
-            Configuration = DotNet.BuildConfiguration.Release
-            MSBuildParams = {
-                p.MSBuildParams with
-                                Properties = [
-                                    "PackageReleaseNotes", String.toLines release.Notes
-                                    "PackageVersion", release.NugetVersion
-                                ]
-            }
-            OutputPath = Some "bin"
-        }
-    ) "FsLexYacc.sln"
+    let releaseNotes = String.toLines release.Notes
+    dotnet $"pack FsLexYacc.sln -c Release -o bin /p:PackageReleaseNotes=\"{releaseNotes}\" /p:PackageVersion={release.NugetVersion}"
 
     // the meta-package
     Paket.pack (fun p ->
@@ -185,7 +174,6 @@ Target.create "NuGet" (fun _ ->
             ToolType = ToolType.CreateLocalTool()
             TemplateFile = "nuget/FsLexYacc.template"
             Version = release.NugetVersion
-
             OutputPath = "bin"
             ReleaseNotes = String.toLines release.Notes })
 )


### PR DESCRIPTION
Similar to how it is done in https://github.com/fsprojects/FSharp.Formatting, this releases new versions when the release notes on the master branch are bumped.
