### PR TITLE
Update FSharp.Core restriction.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 11.0.1 - 10 January, 2022
+* Resolve FSharp.Core dependency restriction #168
+
 #### 11.0.0 - 10 January, 2022
 * Migration to net6.0 #166
 * Fix Activating case insensitive option crash the lexer generator #141

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,7 @@ source https://api.nuget.org/v3/index.json
 storage: none
 frameworks: netstandard2.0, net6.0
 
-nuget FSharp.Core ~> 4.6.0
+nuget FSharp.Core >= 4.6.0
 nuget FsLexYacc copy_local: true
 nuget Microsoft.SourceLink.GitHub copy_local: true
 nuget Expecto ~> 9.0

--- a/src/FsLex.Core/AssemblyInfo.fs
+++ b/src/FsLex.Core/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLex.Core")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.0")>]
+[<assembly: AssemblyVersionAttribute("11.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLex.Core"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.0"
-    let [<Literal>] AssemblyFileVersion = "11.0.0"
+    let [<Literal>] AssemblyVersion = "11.0.1"
+    let [<Literal>] AssemblyFileVersion = "11.0.1"

--- a/src/FsLex/AssemblyInfo.fs
+++ b/src/FsLex/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLex")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.0")>]
+[<assembly: AssemblyVersionAttribute("11.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLex"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.0"
-    let [<Literal>] AssemblyFileVersion = "11.0.0"
+    let [<Literal>] AssemblyVersion = "11.0.1"
+    let [<Literal>] AssemblyFileVersion = "11.0.1"

--- a/src/FsLexYacc.Runtime/AssemblyInfo.fs
+++ b/src/FsLexYacc.Runtime/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLexYacc.Runtime")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc.Runtime")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.0")>]
+[<assembly: AssemblyVersionAttribute("11.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLexYacc.Runtime"
     let [<Literal>] AssemblyProduct = "FsLexYacc.Runtime"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.0"
-    let [<Literal>] AssemblyFileVersion = "11.0.0"
+    let [<Literal>] AssemblyVersion = "11.0.1"
+    let [<Literal>] AssemblyFileVersion = "11.0.1"

--- a/src/FsYacc.Core/AssemblyInfo.fs
+++ b/src/FsYacc.Core/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsYacc.Core")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.0")>]
+[<assembly: AssemblyVersionAttribute("11.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsYacc.Core"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.0"
-    let [<Literal>] AssemblyFileVersion = "11.0.0"
+    let [<Literal>] AssemblyVersion = "11.0.1"
+    let [<Literal>] AssemblyFileVersion = "11.0.1"

--- a/src/FsYacc/AssemblyInfo.fs
+++ b/src/FsYacc/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsYacc")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.0")>]
+[<assembly: AssemblyVersionAttribute("11.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsYacc"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.0"
-    let [<Literal>] AssemblyFileVersion = "11.0.0"
+    let [<Literal>] AssemblyVersion = "11.0.1"
+    let [<Literal>] AssemblyFileVersion = "11.0.1"


### PR DESCRIPTION
When installing `11.0.0`, I noticed:

>  warning NU1608: Detected package version outside of dependency constraint: FsLexYacc.Runtime 11.0.0 requires FSharp.Core (>= 4.6.2 && < 4.7.0) but version FSharp.Core 6.0.1 was resolved.

Updating the restriction to be:

![image](https://user-images.githubusercontent.com/2621499/211510129-9214ddb9-ac85-4573-a31e-36570d80c668.png)

