### PR TITLE
Add `--buffer-type-argument` option for fsyacc.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 11.1.0 - 3 May, 2022
+* Add `--buffer-type-argument` option for fsyacc.
+
 #### 11.0.1 - 10 January, 2022
 * Resolve FSharp.Core dependency restriction #168
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 11.1.0 - 3 May, 2022
+#### 11.1.0 - 3 May, 2023
 * Add `--buffer-type-argument` option for fsyacc.
 
 #### 11.0.1 - 10 January, 2022

--- a/src/FsYacc.Core/fsyaccdriver.fs
+++ b/src/FsYacc.Core/fsyaccdriver.fs
@@ -157,7 +157,8 @@ type GeneratorState =
    compat: bool
    generate_nonterminal_name: Identifier -> string
    map_action_to_int: Action -> int
-   anyMarker: int }
+   anyMarker: int
+   bufferTypeArgument: string }
    with 
    static member Default = 
     {  input = ""
@@ -172,7 +173,8 @@ type GeneratorState =
        compat = false
        generate_nonterminal_name = generic_nt_name
        map_action_to_int = actionCoding
-       anyMarker = anyMarker }
+       anyMarker = anyMarker
+       bufferTypeArgument = "'cty" }
 
 let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compiledSpec: CompiledSpec) = 
       let output, outputi = deriveOutputFileNames (generatorState.input, generatorState.output)
@@ -299,8 +301,6 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
             id
             (match typ with Some _ -> "_fsyacc_x" | None -> "")
             (match typ with Some _ -> "Microsoft.FSharp.Core.Operators.box _fsyacc_x" | None -> "(null : System.Object)")
-
-      let tychar = "'cty" 
 
       for key,_ in spec.Types |> Seq.countBy fst |> Seq.filter (fun (_,n) -> n > 1)  do
             failwithf "%s is given multiple %%type declarations" key;
@@ -539,7 +539,7 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
           if not (types.ContainsKey id) then 
             failwith ("a %type declaration is required for start token "+id);
           let ty = types.[id] in 
-          writer.WriteLineInterface "val %s : (%s.LexBuffer<%s> -> token) -> %s.LexBuffer<%s> -> (%s) " id generatorState.lexlib tychar generatorState.lexlib tychar ty;
+          writer.WriteLineInterface "val %s : (%s.LexBuffer<%s> -> token) -> %s.LexBuffer<%s> -> (%s) " id generatorState.lexlib generatorState.bufferTypeArgument generatorState.lexlib generatorState.bufferTypeArgument ty;
 
 
 let compileSpec (spec: ParserSpec) (logger: Logger) = 

--- a/src/FsYacc/fsyacc.fs
+++ b/src/FsYacc/fsyacc.fs
@@ -22,6 +22,7 @@ let mutable light = None
 let mutable inputCodePage = None
 let mutable lexlib = "FSharp.Text.Lexing"
 let mutable parslib = "FSharp.Text.Parsing"
+let mutable bufferTypeArgument = "'cty"
 
 let usage =
   [ ArgInfo("-o", ArgType.String (fun s -> out <- Some s), "Name the output file.");
@@ -35,7 +36,8 @@ let usage =
     ArgInfo("--tokens", ArgType.Unit (fun _ -> tokenize <- true), "Simply tokenize the specification file itself."); 
     ArgInfo("--lexlib", ArgType.String (fun s ->  lexlib <- s), "Specify the namespace for the implementation of the lexer (default: FSharp.Text.Lexing)");
     ArgInfo("--parslib", ArgType.String (fun s ->  parslib <- s), "Specify the namespace for the implementation of the parser table interpreter (default: FSharp.Text.Parsing)");
-    ArgInfo("--codepage", ArgType.Int (fun i -> inputCodePage <- Some i), "Assume input lexer specification file is encoded with the given codepage.");  ]
+    ArgInfo("--codepage", ArgType.Int (fun i -> inputCodePage <- Some i), "Assume input lexer specification file is encoded with the given codepage.")
+    ArgInfo("--buffer-type-argument", ArgType.String (fun s -> bufferTypeArgument <- s), "Generic type argument of the LexBuffer type."); ]
 
 let _ = ArgParser.Parse(usage,(fun x -> match input with Some _ -> failwith "more than one input given" | None -> input <- Some x),"fsyacc <filename>")
 
@@ -77,7 +79,8 @@ let main() =
           opens = opens
           lexlib = lexlib
           parslib = parslib
-          compat = compat }
+          compat = compat
+          bufferTypeArgument = bufferTypeArgument }
   writeSpecToFile generatorState spec compiledSpec
 
 let result = 


### PR DESCRIPTION
I'm trying to use the generated signature files in the Compiler codebase, but the signature differs from what the compiler needs.

What I need:
```fsharp
val signatureFile : (Internal.Utilities.Text.Lexing.LexBuffer<char> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<char> -> (ParsedSigFile) 
val implementationFile : (Internal.Utilities.Text.Lexing.LexBuffer<char> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<char> -> (ParsedImplFile) 
val interaction : (Internal.Utilities.Text.Lexing.LexBuffer<char> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<char> -> (ParsedScriptInteraction) 
val typedSequentialExprEOF : (Internal.Utilities.Text.Lexing.LexBuffer<char> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<char> -> (SynExpr) 
val typEOF : (Internal.Utilities.Text.Lexing.LexBuffer<char> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<char> -> (SynType) 
```

What is generated:
```fsharp
val signatureFile : (Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> (ParsedSigFile) 
val implementationFile : (Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> (ParsedImplFile) 
val interaction : (Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> (ParsedScriptInteraction) 
val typedSequentialExprEOF : (Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> (SynExpr) 
val typEOF : (Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> token) -> Internal.Utilities.Text.Lexing.LexBuffer<'cty> -> (SynType) 
```

I'd rather not change the compiler code too much, so I'd like to make the type argument configurable via the `--buffer-type-argument`.