### PR TITLE
write module and opens from topcode to signature file

### DIFF
--- a/src/FsLex.Core/fslexdriver.fs
+++ b/src/FsLex.Core/fslexdriver.fs
@@ -118,7 +118,17 @@ let writeOpens opens (writer: Writer) =
         writer.WriteLine ""
         writer.WriteLineInterface ""
 
-let writeTopCode code (writer: Writer) = writer.WriteCode code
+let writeTopCode code (writer: Writer) =
+    writer.WriteCode code
+
+    let moduleAndOpens =
+        (fst code).Split([| '\n'; '\r' |])
+        |> Array.filter (fun s ->
+            s.StartsWith("module ", StringComparison.Ordinal)
+            || s.StartsWith("open ", StringComparison.Ordinal))
+        |> String.concat Environment.NewLine
+
+    writer.WriteInterface "%s" moduleAndOpens
 
 let writeUnicodeTranslationArray dfaNodes domain (writer: Writer) =
     let parseContext =


### PR DESCRIPTION
Currently, our auto-generated signatures suffer from a missing module expression and missing opens.
These make their way into the impl file via the TopCode part. This PR uses this mechanism to put these lines into the sig file, too.