### PR TITLE
Added `--quiet` option to FsLex and FsYacc. 

### DIFF
--- a/src/FsLex/fslex.fs
+++ b/src/FsLex/fslex.fs
@@ -21,6 +21,7 @@ let mutable opens = []
 let mutable lexlib = "FSharp.Text.Lexing"
 let mutable unicode = false
 let mutable caseInsensitive = false
+let mutable quiet = false
 
 let usage =
     [
@@ -46,6 +47,7 @@ let usage =
         )
         ArgInfo("--unicode", ArgType.Unit(fun () -> unicode <- true), "Produce a lexer for use with 16-bit unicode characters.")
         ArgInfo("-i", ArgType.Unit(fun () -> caseInsensitive <- true), "Produce a case-insensitive lexer.")
+        ArgInfo("--quiet", ArgType.Unit(fun () -> quiet <- true), "Suppress all output except errors.")
     ]
 
 let _ =
@@ -62,6 +64,14 @@ let compileSpec (spec: Spec) (ctx: ParseContext) =
     let perRuleData, dfaNodes = Compile ctx spec
     let dfaNodes = dfaNodes |> List.sortBy (fun n -> n.Id)
     perRuleData, dfaNodes
+
+let inline qprintf fmt =
+    fprintf
+        (if quiet then
+             System.IO.TextWriter.Null
+         else
+             System.Console.Out)
+        fmt
 
 let main () =
     try
@@ -91,11 +101,10 @@ let main () =
 
                 exit 1
 
-        printfn "compiling to dfas (can take a while...)"
+        qprintf "compiling to dfas (can take a while...)"
         let perRuleData, dfaNodes = compileSpec spec parseContext
-        printfn "%d states" dfaNodes.Length
-
-        printfn "writing output"
+        qprintf "%d states" dfaNodes.Length
+        qprintf "writing output"
 
         let output =
             match out with


### PR DESCRIPTION
This option suppresses the output of the generated code to the console. The generated code is still written to the output file.

If anyone has better approach to the issue, please advise. Also, not sure where/how to test it.

I will pick this later to `dotnet/fsharp`'s local copies.

**Update:** reasoning is to suppress output when working with compiler, output is useless for 99% of contributors in 99% of cases.