### PR TITLE
sync AssemblyVersion/AssemblyFileVersion with RELEASE_NOTES

### DIFF
--- a/src/FsLex.Core/AssemblyInfo.fs
+++ b/src/FsLex.Core/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLex.Core")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
+[<assembly: AssemblyVersionAttribute("11.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("11.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLex.Core"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.1"
-    let [<Literal>] AssemblyFileVersion = "11.0.1"
+    let [<Literal>] AssemblyVersion = "11.2.0"
+    let [<Literal>] AssemblyFileVersion = "11.2.0"

--- a/src/FsLex/AssemblyInfo.fs
+++ b/src/FsLex/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLex")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
+[<assembly: AssemblyVersionAttribute("11.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("11.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLex"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.1"
-    let [<Literal>] AssemblyFileVersion = "11.0.1"
+    let [<Literal>] AssemblyVersion = "11.2.0"
+    let [<Literal>] AssemblyFileVersion = "11.2.0"

--- a/src/FsLexYacc.Runtime/AssemblyInfo.fs
+++ b/src/FsLexYacc.Runtime/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsLexYacc.Runtime")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc.Runtime")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
+[<assembly: AssemblyVersionAttribute("11.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("11.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsLexYacc.Runtime"
     let [<Literal>] AssemblyProduct = "FsLexYacc.Runtime"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.1"
-    let [<Literal>] AssemblyFileVersion = "11.0.1"
+    let [<Literal>] AssemblyVersion = "11.2.0"
+    let [<Literal>] AssemblyFileVersion = "11.2.0"

--- a/src/FsYacc.Core/AssemblyInfo.fs
+++ b/src/FsYacc.Core/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsYacc.Core")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
+[<assembly: AssemblyVersionAttribute("11.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("11.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsYacc.Core"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.1"
-    let [<Literal>] AssemblyFileVersion = "11.0.1"
+    let [<Literal>] AssemblyVersion = "11.2.0"
+    let [<Literal>] AssemblyFileVersion = "11.2.0"

--- a/src/FsYacc/AssemblyInfo.fs
+++ b/src/FsYacc/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsYacc")>]
 [<assembly: AssemblyProductAttribute("FsLexYacc")>]
 [<assembly: AssemblyDescriptionAttribute("FsLex/FsYacc lexer/parser generation tools")>]
-[<assembly: AssemblyVersionAttribute("11.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("11.0.1")>]
+[<assembly: AssemblyVersionAttribute("11.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("11.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsYacc"
     let [<Literal>] AssemblyProduct = "FsLexYacc"
     let [<Literal>] AssemblyDescription = "FsLex/FsYacc lexer/parser generation tools"
-    let [<Literal>] AssemblyVersion = "11.0.1"
-    let [<Literal>] AssemblyFileVersion = "11.0.1"
+    let [<Literal>] AssemblyVersion = "11.2.0"
+    let [<Literal>] AssemblyFileVersion = "11.2.0"


### PR DESCRIPTION
I think this was forgotten for the last few releases.