### PR TITLE
Additional #nowarn directives in the generated code

### DIFF
--- a/src/FsYacc.Core/fsyaccdriver.fs
+++ b/src/FsYacc.Core/fsyaccdriver.fs
@@ -227,6 +227,11 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
     writer.WriteLine
         "#nowarn \"64\";; // turn off warnings that type variables used in production annotations are instantiated to concrete type"
 
+    writer.WriteLine "#nowarn \"1182\"  // the generated code often has unused variable 'parseState'"
+
+    writer.WriteLine
+        "#nowarn \"3261\"  // the generated code would need to properly annotate nulls, e.g. changing System.Object to `obj|null`"
+
     for s in generatorState.opens do
         writer.WriteLine "open %s" s
         writer.WriteLineInterface "open %s" s


### PR DESCRIPTION
https://github.com/dotnet/fsharp/pull/17649 slightly changes the way #nowarn will work in F# 9.
This PR brings the adaptation in fsyacc upstream.