### PR TITLE
Additional nowarn directives in the generated code (part 2)

### DIFF
--- a/src/FsYacc.Core/fsyaccdriver.fs
+++ b/src/FsYacc.Core/fsyaccdriver.fs
@@ -225,7 +225,7 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
             writer.WriteLineInterface "module %s" s
 
     writer.WriteLine
-        "#nowarn \"64\";; // turn off warnings that type variables used in production annotations are instantiated to concrete type"
+        "#nowarn \"64\" // turn off warnings that type variables used in production annotations are instantiated to concrete type"
 
     writer.WriteLine "#nowarn \"1182\"  // the generated code often has unused variable 'parseState'"
 

--- a/src/FsYacc.Core/fsyaccpars.fsy
+++ b/src/FsYacc.Core/fsyaccpars.fsy
@@ -7,6 +7,7 @@ open FsLexYacc.FsYacc
 open FsLexYacc.FsYacc.AST
 
 #nowarn "62" // This construct is for ML compatibility
+#nowarn "64" // Turn off warnings that type variables used in production annotations are instantiated to concrete type"
 
 %} 
 


### PR DESCRIPTION
This PR adds to the changes made in #218.
As discussed [in the compiler repo](https://github.com/dotnet/fsharp/pull/17724), the [fix 17649](https://github.com/dotnet/fsharp/pull/17649) will create the need for the additional `#nowarn` in `fscaccpars.fsy`.