### PR TITLE
Fix compile errors in fsyacc's output if there is no header in the input file.

### DIFF
--- a/src/FsYacc.Core/fsyaccdriver.fs
+++ b/src/FsYacc.Core/fsyaccdriver.fs
@@ -120,7 +120,11 @@ type Writer(outputFileName, outputFileInterface) =
     member x.WriteUInt16(i: int) = fprintf os "%dus;" i
 
     member x.WriteCode(code, pos) =
-        x.WriteLine "# %d \"%s\"" pos.pos_lnum pos.pos_fname
+        // This can arise if there was no header in the input file.
+        // A line directive with an empty file name causes a compiler error.
+        if pos.pos_fname <> "" then
+            x.WriteLine "# %d \"%s\"" pos.pos_lnum pos.pos_fname
+
         x.WriteLine "%s" code
         let codeLines = code.Replace("\r", "").Split([| '\n' |]).Length
         outputLineCount <- outputLineCount + codeLines

--- a/src/FsYacc.Core/fsyaccdriver.fs
+++ b/src/FsYacc.Core/fsyaccdriver.fs
@@ -120,15 +120,12 @@ type Writer(outputFileName, outputFileInterface) =
     member x.WriteUInt16(i: int) = fprintf os "%dus;" i
 
     member x.WriteCode(code, pos) =
-        // This can arise if there was no header in the input file.
-        // A line directive with an empty file name causes a compiler error.
-        if pos.pos_fname <> "" then
+        if code <> "" then
             x.WriteLine "# %d \"%s\"" pos.pos_lnum pos.pos_fname
-
-        x.WriteLine "%s" code
-        let codeLines = code.Replace("\r", "").Split([| '\n' |]).Length
-        outputLineCount <- outputLineCount + codeLines
-        x.WriteLine "# %d \"%s\"" outputLineCount outputFileName
+            x.WriteLine "%s" code
+            let codeLines = code.Replace("\r", "").Split([| '\n' |]).Length
+            outputLineCount <- outputLineCount + codeLines
+            x.WriteLine "# %d \"%s\"" outputLineCount outputFileName
 
     member x.OutputLineCount = outputLineCount
 

--- a/tests/LexAndYaccMiniProject/Parser.fsy
+++ b/tests/LexAndYaccMiniProject/Parser.fsy
@@ -1,9 +1,4 @@
-﻿%{
-
-
-%}
-
-// The start token becomes a parser function in the compiled code:
+﻿// The start token becomes a parser function in the compiled code:
 %start start
 
 // Regular tokens


### PR DESCRIPTION
The header in `.fsy` files [is optional](https://github.com/fsprojects/FsLexYacc/blob/e8a44816d56159cab3fa0a3c6b8715d08f6355d3/src/FsYacc.Core/fsyaccpars.fsy#L28-L32). However if it does not exist, FsYacc will emit a `#0 ""` line directive in the source file, and the compiler [will not like](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AbEAzAzgHwGIAGAAgCJyBYAKFogAcYA7UgZQE9cAXGAW1rcOTUgGEAFAEpSAXlqkFpPv2AwopAPoA6ALJTZpKUA===) the empty string in the file name. This PR fixes FsYacc to not emit any line directives if the header is empty.

Validated by removing the header from the mini project.